### PR TITLE
Import pathlib for Lesson 2 Download notebook

### DIFF
--- a/nbs/dl1/lesson2-download.ipynb
+++ b/nbs/dl1/lesson2-download.ipynb
@@ -29,6 +29,7 @@
    "outputs": [],
    "source": [
     "from fastai.vision import *"
+    "from pathlib import Path"
    ]
   },
   {


### PR DESCRIPTION
While working on FastAI Part I 2019 - Lesson 2 Download notebook, I needed to add an import for `pathlib`.  `from fastai import *` was removed in [615585c43f0fc4e19b28101940267c1bacfd507d](https://github.com/adamzolyak/course-v3/commit/615585c43f0fc4e19b28101940267c1bacfd507d#diff-a6a99a9fec5d1223cb568e2e1a02a509) which had previously imported `pathlib`.